### PR TITLE
Add About navigation link to navbar

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -47,6 +47,7 @@ const Navbar = () => {
   }, [location]);
 
   const navItems = [
+    { name: "About", path: "/about" },
     { name: "Projects", path: "/projects" },
     { name: "Experience", path: "/experience" },
     { name: "CV", path: "/cv" }


### PR DESCRIPTION
The About page existed but was not accessible from the navigation menu. Added the About route to the navItems array so it appears in both desktop and mobile navigation.